### PR TITLE
Fixed Javadoc generation issue

### DIFF
--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnSubstring.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnSubstring.java
@@ -21,12 +21,14 @@ import java.util.List;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 /**
- * Implements <a href= "https://www.w3.org/TR/xpath-functions-31/#func-substring">fn:substring</a>.
+ * Implements <a href=
+ * "https://www.w3.org/TR/xpath-functions-31/#func-substring">fn:substring</a>.
  */
 public final class FnSubstring {
+  private static final String NAME = "substring";
   @NonNull
   static final IFunction SIGNATURE_TWO_ARG = IFunction.builder()
-      .name("substring")
+      .name(NAME)
       .namespace(MetapathConstants.NS_METAPATH_FUNCTIONS)
       .deterministic()
       .contextIndependent()
@@ -46,8 +48,9 @@ public final class FnSubstring {
       .functionHandler(FnSubstring::executeTwoArg)
       .build();
 
+  @NonNull
   static final IFunction SIGNATURE_THREE_ARG = IFunction.builder()
-      .name("substring")
+      .name(NAME)
       .namespace(MetapathConstants.NS_METAPATH_FUNCTIONS)
       .deterministic()
       .contextIndependent()
@@ -76,7 +79,7 @@ public final class FnSubstring {
     // disable construction
   }
 
-  @SuppressWarnings("unused")
+  @SuppressWarnings({ "unused", "PMD.OnlyOneReturn" })
   @NonNull
   private static ISequence<IStringItem> executeTwoArg(
       @NonNull IFunction function,
@@ -94,13 +97,14 @@ public final class FnSubstring {
 
     int startIndex = start.round().asInteger().intValue();
 
-    return ISequence.of(fnSubstring(
-        sourceString.asString(),
-        startIndex,
-        sourceString.toString().length() - Math.max(startIndex, 1) + 1));
+    return ISequence.of(IStringItem.valueOf(
+        fnSubstring(
+            sourceString.asString(),
+            startIndex,
+            sourceString.toString().length() - Math.max(startIndex, 1) + 1)));
   }
 
-  @SuppressWarnings("unused")
+  @SuppressWarnings({ "unused", "PMD.OnlyOneReturn" })
   @NonNull
   private static ISequence<IStringItem> executeThreeArg(
       @NonNull IFunction function,
@@ -117,26 +121,27 @@ public final class FnSubstring {
     IDecimalItem start = FunctionUtils.asType(ObjectUtils.requireNonNull(arguments.get(1).getFirstItem(true)));
     IDecimalItem length = FunctionUtils.asType(ObjectUtils.requireNonNull(arguments.get(2).getFirstItem(true)));
 
-    return ISequence.of(fnSubstring(
-        sourceString.asString(),
-        start.round().asInteger().intValue(),
-        length.round().asInteger().intValue()));
+    return ISequence.of(IStringItem.valueOf(
+        fnSubstring(
+            sourceString.asString(),
+            start.round().asInteger().intValue(),
+            length.round().asInteger().intValue())));
   }
 
   /**
-   * An implementation of XPath 3.1
-   * <a href= "https://www.w3.org/TR/xpath-functions-31/#func-substring">fn:substring</a>.
+   * An implementation of XPath 3.1 <a href=
+   * "https://www.w3.org/TR/xpath-functions-31/#func-substring">fn:substring</a>.
    *
-   * @param sourceString
-   *
+   * @param source
+   *          the source string to get a substring from
    * @param start
-   *
+   *          the 1-based start location
    * @param length
-   *
-   * @return the atomized result
+   *          the substring length
+   * @return the substring
    */
   @NonNull
-  public static IStringItem fnSubstring(
+  public static String fnSubstring(
       @NonNull String source,
       int start,
       int length) {
@@ -151,6 +156,6 @@ public final class FnSubstring {
     // Ensure startIndex is not greater than endIndex
     startIndex = Math.min(startIndex, endIndex);
 
-    return IStringItem.valueOf(source.substring(startIndex - 1, endIndex - 1));
+    return ObjectUtils.notNull(source.substring(startIndex - 1, endIndex - 1));
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -85,6 +85,7 @@
 		<plugin.antlr4test.version>1.22</plugin.antlr4test.version>
 		<plugin.appassembler.version>2.1.0</plugin.appassembler.version>
 		<plugin.git-commit-id.version>9.0.1</plugin.git-commit-id.version>
+		<plugin.maven-javadoc.version>3.10.1</plugin.maven-javadoc.version>
 		<plugin.maven-changes.version>2.12.1</plugin.maven-changes.version>
 		<plugin.maven-invoker.version>3.8.0</plugin.maven-invoker.version>
 		<plugin.maven-toolchains.version>3.2.0</plugin.maven-toolchains.version>
@@ -579,9 +580,11 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-javadoc-plugin</artifactId>
+					<version>${plugin.maven-javadoc.version}</version>
 					<configuration>
 						<excludePackageNames>*.xmlbeans:*.xmlbeans.*:*.antlr</excludePackageNames>
 						<failOnWarnings>false</failOnWarnings>
+						<failOnError>true</failOnError>
 					</configuration>
 				</plugin>
 				<plugin>


### PR DESCRIPTION
# Committer Notes

Fixed Javadoc generation issue. Also bumped Javadoc plugin version.

### All Submissions:

- [ ] Have you followed the guidelines in our [Contributing](https://github.com/metaschema-framework/metaschema-java/blob/main/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/metaschema-framework/metaschema-java/pulls) for the same update/change?
- [ ] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [ ] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.

### Changes to Core Features:

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you included examples of how to use your new feature(s)?
- [ ] Have you updated all website and readme documentation affected by the changes you made?
