### PR TITLE
…

### DIFF
--- a/core/src/main/java/gov/nist/secauto/metaschema/core/model/AbstractGlobalDefinition.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/model/AbstractGlobalDefinition.java
@@ -61,12 +61,6 @@ public abstract class AbstractGlobalDefinition<MODULE extends IModule, INSTANCE 
   }
 
   @Override
-  public final boolean isInline() {
-    // never inline
-    return false;
-  }
-
-  @Override
   public final INSTANCE getInlineInstance() {
     // never inline
     return null;

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/RootAssemblyBindingMatcher.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/RootAssemblyBindingMatcher.java
@@ -51,4 +51,9 @@ class RootAssemblyBindingMatcher implements IBindingMatcher {
   public Class<? extends IBoundObject> getBoundClassForJsonName(String rootName) {
     return getRootJsonName().equals(rootName) ? getClazz() : null;
   }
+
+  @Override
+  public String toString() {
+    return getDefinition().getRootXmlQName().toString();
+  }
 }

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/IBoundDefinitionModelComplex.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/IBoundDefinitionModelComplex.java
@@ -26,11 +26,6 @@ public interface IBoundDefinitionModelComplex
   @NonNull
   Map<String, IBoundProperty<?>> getJsonProperties(@Nullable Predicate<IBoundInstanceFlag> flagFilter);
 
-  @Override
-  default boolean isInline() {
-    return getBoundClass().getEnclosingClass() != null;
-  }
-
   @Nullable
   Method getBeforeDeserializeMethod();
 

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/impl/AbstractBoundDefinitionModelComplex.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/impl/AbstractBoundDefinitionModelComplex.java
@@ -97,11 +97,6 @@ public abstract class AbstractBoundDefinitionModelComplex<A extends Annotation>
   }
 
   @Override
-  public boolean isInline() {
-    return getBoundClass().getEnclosingClass() != null;
-  }
-
-  @Override
   public Method getBeforeDeserializeMethod() {
     return beforeDeserializeMethod;
   }

--- a/metaschema-cli/src/main/java/gov/nist/secauto/metaschema/cli/commands/AbstractValidateContentCommand.java
+++ b/metaschema-cli/src/main/java/gov/nist/secauto/metaschema/cli/commands/AbstractValidateContentCommand.java
@@ -290,8 +290,8 @@ public abstract class AbstractValidateContentCommand
 
       IValidationResult validationResult = null;
       try {
+        IModule module = getModule(getCommandLine(), bindingContext);
         if (!cmdLine.hasOption(NO_SCHEMA_VALIDATION_OPTION)) {
-          IModule module = getModule(getCommandLine(), bindingContext);
           // perform schema validation
           validationResult = getSchemaValidationProvider(module, getCommandLine(), bindingContext)
               .validateWithSchema(source, asFormat, bindingContext);

--- a/metaschema-cli/src/main/java/gov/nist/secauto/metaschema/cli/commands/ValidateContentUsingModuleCommand.java
+++ b/metaschema-cli/src/main/java/gov/nist/secauto/metaschema/cli/commands/ValidateContentUsingModuleCommand.java
@@ -105,6 +105,7 @@ public class ValidateContentUsingModuleCommand
             MetaschemaCommands.METASCHEMA_REQUIRED_OPTION,
             cwd,
             bindingContext);
+        module = bindingContext.registerModule(module);
       } catch (URISyntaxException ex) {
         throw new IOException(String.format("Cannot load module as '%s' is not a valid file or URL.", ex.getInput()),
             ex);

--- a/metaschema-cli/src/test/java/gov/nist/secauto/metaschema/cli/CLITest.java
+++ b/metaschema-cli/src/test/java/gov/nist/secauto/metaschema/cli/CLITest.java
@@ -12,6 +12,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import gov.nist.secauto.metaschema.cli.processor.ExitCode;
 import gov.nist.secauto.metaschema.cli.processor.ExitStatus;
 
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -44,7 +45,8 @@ public class CLITest {
   }
 
   private static Stream<Arguments> providesValues() {
-    @SuppressWarnings("serial") List<Arguments> values = new LinkedList<>() {
+    @SuppressWarnings("serial")
+    List<Arguments> values = new LinkedList<>() {
       {
         add(Arguments.of(new String[] {}, ExitCode.INVALID_COMMAND,
             NO_EXCEPTION_CLASS));
@@ -188,7 +190,7 @@ public class CLITest {
                 "--show-stack-trace"
             },
             ExitCode.FAIL, NO_EXCEPTION_CLASS));
-        ;
+
       }
     };
     return values.stream();
@@ -206,5 +208,17 @@ public class CLITest {
     } else {
       evaluateResult(CLI.runCli(fullArgs), expectedExitCode, expectedThrownClass);
     }
+  }
+
+  @Test
+  void test() {
+    String[] cliArgs = { "validate-content",
+        "-m",
+        "src/test/resources/content/215-module.xml",
+        "src/test/resources/content/215.xml",
+        "--disable-schema-validation",
+        "--show-stack-trace"
+    };
+    CLI.runCli(cliArgs);
   }
 }


### PR DESCRIPTION
# Committer Notes

Fixed multiple bugs causing an issue around validating a content instance. The first was that the module was not being loaded for constraint validation due to the load happening inside the disabled schema validation block. The second was a tricky issue on loading the module, where some definitions were mistaken found to be inline, when they had separate definition classes.

### All Submissions:

- [ ] Have you followed the guidelines in our [Contributing](https://github.com/metaschema-framework/metaschema-java/blob/main/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/metaschema-framework/metaschema-java/pulls) for the same update/change?
- [ ] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [ ] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.

### Changes to Core Features:

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you included examples of how to use your new feature(s)?
- [ ] Have you updated all website and readme documentation affected by the changes you made?
