### PR TITLE
Ensure that external constraints can be applied to the built-in Metaschema module module

### DIFF
--- a/core/src/test/resources/log4j2-test.xml
+++ b/core/src/test/resources/log4j2-test.xml
@@ -13,11 +13,6 @@
 		<Logger name="gov.nist.secauto.metaschema" level="info" additivity="false">
 			<AppenderRef ref="console" />
 		</Logger>
-<!-- 
-		<Logger name="gov.nist.secauto.metaschema.core.metapath" level="debug" additivity="false">
-			<AppenderRef ref="console" />
-		</Logger>
- -->
 		<Root level="info">
 			<AppenderRef ref="console" />
 		</Root>

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/AbstractModuleLoaderStrategy.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/AbstractModuleLoaderStrategy.java
@@ -7,6 +7,7 @@ package gov.nist.secauto.metaschema.databind;
 
 import gov.nist.secauto.metaschema.core.model.IBoundObject;
 import gov.nist.secauto.metaschema.core.model.IModule;
+import gov.nist.secauto.metaschema.core.model.constraint.DefaultConstraintValidator;
 import gov.nist.secauto.metaschema.core.util.ObjectUtils;
 import gov.nist.secauto.metaschema.databind.IBindingContext.IBindingMatcher;
 import gov.nist.secauto.metaschema.databind.model.IBoundDefinitionModelAssembly;
@@ -18,16 +19,23 @@ import gov.nist.secauto.metaschema.databind.model.annotations.MetaschemaModule;
 import gov.nist.secauto.metaschema.databind.model.annotations.ModelUtil;
 import gov.nist.secauto.metaschema.databind.model.impl.DefinitionAssembly;
 import gov.nist.secauto.metaschema.databind.model.impl.DefinitionField;
+import gov.nist.secauto.metaschema.databind.model.metaschema.binding.MetaschemaModelModule;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.stream.Collectors;
+
+import javax.xml.namespace.QName;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 
@@ -37,9 +45,11 @@ import edu.umd.cs.findbugs.annotations.NonNull;
  * @since 2.0.0
  */
 public abstract class AbstractModuleLoaderStrategy implements IBindingContext.IModuleLoaderStrategy {
+  private static final Logger LOGGER = LogManager.getLogger(DefaultConstraintValidator.class);
+
   @SuppressWarnings("PMD.UseConcurrentHashMap")
   @NonNull
-  private final Map<IBoundDefinitionModelAssembly, IBindingMatcher> bindingMatchers = new HashMap<>();
+  private final Map<QName, IBindingMatcher> bindingMatchers = new LinkedHashMap<>();
   @NonNull
   private final Map<IModule, IBoundModule> moduleToBoundModuleMap = new ConcurrentHashMap<>();
   @SuppressWarnings("PMD.UseConcurrentHashMap")
@@ -138,17 +148,30 @@ public abstract class AbstractModuleLoaderStrategy implements IBindingContext.IM
     IBindingMatcher retval;
     modulesLock.lock();
     try {
-      retval = bindingMatchers.get(definition);
-      if (retval == null) {
-        if (!definition.isRoot()) {
-          throw new IllegalArgumentException(
-              String.format("The provided definition '%s' is not a root assembly.",
-                  definition.getBoundClass().getName()));
-        }
-
-        retval = IBindingMatcher.of(definition);
-        bindingMatchers.put(definition, retval);
+      if (!definition.isRoot()) {
+        throw new IllegalArgumentException(
+            String.format("The provided definition '%s' is not a root assembly.",
+                definition.getBoundClass().getName()));
       }
+      QName qname = definition.getRootXmlQName();
+      retval = IBindingMatcher.of(definition);
+      // always replace the existing matcher to ensure the last loaded module wins
+      IBindingMatcher old = bindingMatchers.put(qname, retval);
+      if (old != null && !(definition.getContainingModule() instanceof MetaschemaModelModule)) {
+        LOGGER.atWarn().log("Replacing matcher for QName: {}", qname);
+      }
+
+      // retval = bindingMatchers.get(definition);
+      // if (retval == null) {
+      // if (!definition.isRoot()) {
+      // throw new IllegalArgumentException(
+      // String.format("The provided definition '%s' is not a root assembly.",
+      // definition.getBoundClass().getName()));
+      // }
+      //
+      // retval = IBindingMatcher.of(definition);
+      // bindingMatchers.put(definition, retval);
+      // }
     } finally {
       modulesLock.unlock();
     }

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/DefaultBindingContext.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/DefaultBindingContext.java
@@ -117,8 +117,7 @@ public class DefaultBindingContext implements IBindingContext {
   public final IBoundModule registerModule(@NonNull Class<? extends IBoundModule> clazz) {
     IModuleLoaderStrategy strategy = getModuleLoaderStrategy();
     IBoundModule module = strategy.loadModule(clazz, this);
-    strategy.registerModule(module, this);
-    return module;
+    return strategy.registerModule(module, this);
   }
 
   /**

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/PostProcessingModuleLoaderStrategy.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/PostProcessingModuleLoaderStrategy.java
@@ -12,7 +12,6 @@ import gov.nist.secauto.metaschema.core.util.CollectionUtil;
 import gov.nist.secauto.metaschema.databind.IBindingContext.IBindingMatcher;
 import gov.nist.secauto.metaschema.databind.model.IBoundDefinitionModelComplex;
 import gov.nist.secauto.metaschema.databind.model.IBoundModule;
-import gov.nist.secauto.metaschema.databind.model.metaschema.binding.MetaschemaModelModule;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -80,16 +79,18 @@ public class PostProcessingModuleLoaderStrategy
     return boundModule;
   }
 
-  private void processModule(@NonNull IModule module) {
+  /**
+   * Perform post-processing on the provided module.
+   *
+   * @param module
+   *          the module to post process
+   */
+  protected void processModule(@NonNull IModule module) {
     postProcessedModulesLock.lock();
     try {
       if (!postProcessedModules.contains(module)) {
-        // do not post-process the built-in Metaschema module, since it has already been
-        // pre-processed
-        if (!(module instanceof MetaschemaModelModule)) {
-          for (IModuleLoader.IModulePostProcessor postProcessor : getModulePostProcessors()) {
-            postProcessor.processModule(module);
-          }
+        for (IModuleLoader.IModulePostProcessor postProcessor : getModulePostProcessors()) {
+          postProcessor.processModule(module);
         }
         postProcessedModules.add(module);
       }

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/BindingConstraintLoader.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/BindingConstraintLoader.java
@@ -33,13 +33,11 @@ import gov.nist.secauto.metaschema.core.model.constraint.ValueConstraintSet;
 import gov.nist.secauto.metaschema.core.util.CollectionUtil;
 import gov.nist.secauto.metaschema.core.util.ObjectUtils;
 import gov.nist.secauto.metaschema.databind.IBindingContext;
-import gov.nist.secauto.metaschema.databind.io.DeserializationFeature;
 import gov.nist.secauto.metaschema.databind.io.IBoundLoader;
 import gov.nist.secauto.metaschema.databind.model.metaschema.binding.AssemblyConstraints;
 import gov.nist.secauto.metaschema.databind.model.metaschema.binding.MetapathContext;
 import gov.nist.secauto.metaschema.databind.model.metaschema.binding.MetaschemaMetaConstraints;
 import gov.nist.secauto.metaschema.databind.model.metaschema.binding.MetaschemaMetapath;
-import gov.nist.secauto.metaschema.databind.model.metaschema.binding.MetaschemaModelModule;
 import gov.nist.secauto.metaschema.databind.model.metaschema.binding.MetaschemaModuleConstraints;
 import gov.nist.secauto.metaschema.databind.model.metaschema.impl.ConstraintBindingSupport;
 
@@ -75,11 +73,8 @@ public class BindingConstraintLoader
   private final IBoundLoader loader;
 
   public BindingConstraintLoader(@NonNull IBindingContext bindingContext) {
-    // ensure the bindings are registered
-    bindingContext.registerModule(MetaschemaModelModule.class);
-
     this.loader = bindingContext.newBoundLoader();
-    this.loader.enableFeature(DeserializationFeature.DESERIALIZE_VALIDATE_CONSTRAINTS);
+    // this.loader.enableFeature(DeserializationFeature.DESERIALIZE_VALIDATE_CONSTRAINTS);
   }
 
   @Override

--- a/metaschema-cli/src/test/java/gov/nist/secauto/metaschema/cli/CLITest.java
+++ b/metaschema-cli/src/test/java/gov/nist/secauto/metaschema/cli/CLITest.java
@@ -226,18 +226,18 @@ public class CLITest {
     }
   }
 
-    @Test
-    void testValidateConstraints() {
-      try (LogCaptor captor = LogCaptor.forRoot()) {
-        String[] cliArgs = { "validate",
-            "src/test/resources/content/constraint-example.xml",
-            "-c",
-            "src/test/resources/content/constraint-constraints.xml",
-            "--disable-schema-validation",            
-        };
-        CLI.runCli(cliArgs);
-        assertThat(captor.getErrorLogs().toString())
-            .contains("This constraint SHOULD be violated if test passes.");
-      }
+  @Test
+  void testValidateConstraints() {
+    try (LogCaptor captor = LogCaptor.forRoot()) {
+      String[] cliArgs = { "validate",
+          "src/test/resources/content/constraint-example.xml",
+          "-c",
+          "src/test/resources/content/constraint-constraints.xml",
+          "--disable-schema-validation",
+      };
+      CLI.runCli(cliArgs);
+      assertThat(captor.getErrorLogs().toString())
+          .contains("This constraint SHOULD be violated if test passes.");
+    }
   }
 }

--- a/metaschema-cli/src/test/resources/content/constraint-constraints.xml
+++ b/metaschema-cli/src/test/resources/content/constraint-constraints.xml
@@ -5,7 +5,7 @@
  	<context>
         <metapath target="/metaschema-meta-constraints"/>
         <constraints>
-            <expect id="prop-help-url-required" target="//expect" test="count(prop[@namespace = 'https://docs.oasis-open.org/sarif/sarif/v2.1.0' and @name = 'help-url']) eq 1" level="ERROR">
+            <expect id="prop-help-url-required" target=".//expect" test="count(prop[@namespace = 'https://docs.oasis-open.org/sarif/sarif/v2.1.0' and @name = 'help-url']) eq 1" level="ERROR">
                 <message>This constraint SHOULD be violated if test passes.</message>
             </expect>
         </constraints>

--- a/metaschema-maven-plugin/src/main/java/gov/nist/secauto/metaschema/maven/plugin/AbstractMetaschemaMojo.java
+++ b/metaschema-maven-plugin/src/main/java/gov/nist/secauto/metaschema/maven/plugin/AbstractMetaschemaMojo.java
@@ -36,6 +36,7 @@ import gov.nist.secauto.metaschema.databind.codegen.config.IBindingConfiguration
 import gov.nist.secauto.metaschema.databind.model.IBoundModule;
 import gov.nist.secauto.metaschema.databind.model.metaschema.IBindingMetaschemaModule;
 import gov.nist.secauto.metaschema.databind.model.metaschema.IBindingModuleLoader;
+import gov.nist.secauto.metaschema.databind.model.metaschema.binding.MetaschemaModelModule;
 
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.DependencyResolutionRequiredException;
@@ -60,6 +61,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -289,7 +291,8 @@ public abstract class AbstractMetaschemaMojo
     // generate Java sources based on provided metaschema sources
     return new DefaultBindingContext(
         new PostProcessingModuleLoaderStrategy(
-            CollectionUtil.singletonList(new ExternalConstraintsModulePostProcessor(constraints)),
+            // ensure that the external constraints do not apply to the built in module
+            CollectionUtil.singletonList(new LimitedExternalConstraintsModulePostProcessor(constraints)),
             new SimpleModuleLoaderStrategy(
                 // this is used instead of the default generator to ensure that plugin classpath
                 // entries are used for compilation
@@ -659,6 +662,25 @@ public abstract class AbstractMetaschemaMojo
         throw new IllegalStateException(ex);
       }
     }
+  }
 
+  private static class LimitedExternalConstraintsModulePostProcessor
+      extends ExternalConstraintsModulePostProcessor {
+
+    public LimitedExternalConstraintsModulePostProcessor(
+        @NonNull Collection<IConstraintSet> additionalConstraintSets) {
+      super(additionalConstraintSets);
+    }
+
+    /**
+     * This method ensures that constraints are not applied to the built-in
+     * Metaschema module module twice, when this module is selected as the source
+     * for generation.
+     */
+    public void processModule(IModule module) {
+      if (!(module instanceof MetaschemaModelModule)) {
+        super.processModule(module);
+      }
+    }
   }
 }


### PR DESCRIPTION
# Committer Notes

Updated Metaschema submodule to latest. This ensures that the changes align with the code changes from #218.

Fixed an issue that prevented constraints to be applied to the built-in Metaschema module module.

Also fixed an issue that prevented newer binding matchers from overriding previous binding matchers where they have the same element names.

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/metaschema-framework/metaschema-java/blob/main/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/metaschema-framework/metaschema-java/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- [ ] Have you included examples of how to use your new feature(s)?
- [ ] Have you updated all website and readme documentation affected by the changes you made?
